### PR TITLE
Add integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 
 # Ignore python files
 *.py
+
+# Custom
+test_parse.toml

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 
 # Custom
 test_parse.toml
+test.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,11 @@ name = "x-ray"
 version = "0.1.0"
 authors = ["dinesh <dineshpy07@gmail.com>"]
 
+[[bin]]
+bench = false
+path = "src/main.rs"
+name = "x-ray"
+
 [dependencies]
 toml = "0.4"
 rustc-serialize = "0.3"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use clap::{Arg, App, SubCommand};
 
 const ABOUT: &'static str = "
@@ -8,7 +10,8 @@ pub struct CliConf {
     pub skip_validations: bool,
     pub conf_file: Option<String>,
     pub parse: bool,
-    pub parse_dir: Option<String>
+    pub parse_dir: Option<String>,
+    pub gen_dir: Option<String>,
 }
 
 // There are 2 main parts
@@ -37,7 +40,11 @@ pub fn main() -> CliConf {
                 .short("f")
                 .value_name("conf_file")
                 .required(true)
-                .help("Provide the conf file")))
+                .help("Provide the conf file"))
+            .arg(Arg::with_name("dir")
+                .short("d")
+                .value_name("dir")
+                .help("Provide the path where the generated code should be put.")))
         .subcommand(SubCommand::with_name("parse")
             .about("parse python source and generate conf file")
             .arg(Arg::with_name("dir")
@@ -56,6 +63,7 @@ pub fn main() -> CliConf {
     let mut skip_validations: bool = false;
     let mut conf_file = "";
     let mut parse_dir = None;
+    let mut gen_dir = Some(get_current_directory());
     if let Some(matches) = matches.subcommand_matches("gen") {
         if matches.is_present("skip_validations") {
             println!("Skipping python validations");
@@ -63,6 +71,7 @@ pub fn main() -> CliConf {
         }
 
         conf_file = matches.value_of("conf_file").unwrap();
+        gen_dir = Some(matches.value_of("dir").unwrap().to_string());
     }
 
     let parse = match matches.subcommand_matches("parse") {
@@ -79,8 +88,14 @@ pub fn main() -> CliConf {
         skip_validations: skip_validations,
         conf_file: Some(conf_file.to_string()),
         parse: parse,
-        parse_dir: parse_dir
+        parse_dir: parse_dir,
+        gen_dir: gen_dir
     };
 
     return cli_conf;
+}
+
+fn get_current_directory() -> String {
+    let cwd = env::current_dir().unwrap();
+    cwd.to_str().unwrap().to_string()
 }

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -1,5 +1,5 @@
-use std::path::Path;
-use std::env;
+use std::path::{Path, PathBuf};
+use std::fs;
 
 use toml;
 
@@ -72,7 +72,7 @@ fn generate_package_src(packages: Vec<Package>, package_path: &Path) {
     }
 }
 
-pub fn generate(skip_validations: bool, conf_file: String) {
+pub fn generate(skip_validations: bool, gen_dir: String, conf_file: String) {
     let toml_file_content = read_file(&conf_file);
     let config: Config = toml::from_str(&toml_file_content).unwrap();
 
@@ -85,7 +85,12 @@ pub fn generate(skip_validations: bool, conf_file: String) {
         validate(&root);
     }
 
-    let root_path = env::current_dir().unwrap();
+    fs::create_dir_all(&gen_dir);
+
+    // let root_path = env::current_dir().unwrap();
+    // let root_path = root_path.as_path();
+    let root_path = PathBuf::from(gen_dir);
     let root_path = root_path.as_path();
+
     generate_package_src(root.packages, root_path);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,27 @@
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
+extern crate toml;
+extern crate regex;
+extern crate clap;
+#[macro_use]
+extern crate nom;
+
+mod template;
+mod structures;
+mod util;
+mod cli;
+mod parser;
+mod parse;
+mod gen;
+
+
+
+pub fn gen(gen_dir: String, conf_file: String) {
+    gen::generate(false, gen_dir, conf_file);
+}
+
+pub fn parse(parse_dir: String, conf_file: String) {
+    let root_res = parse::parse(parse_dir);
+    util::write_to_config(conf_file, root_res);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub fn gen(gen_dir: String, conf_file: String) {
     gen::generate(false, gen_dir, conf_file);
 }
 
-pub fn parse(parse_dir: String, conf_file: String) {
-    let root_res = parse::parse(parse_dir);
+pub fn parse(parse_dir: &str, conf_file: &str) {
+    let root_res = parse::parse(&parse_dir);
     util::write_to_config(conf_file, root_res);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,8 @@ fn main() {
     let gen_dir = cli_values.gen_dir;
 
     if parse_opt {
-        let root_res = parse::parse(parse_dir.unwrap());
-        util::write_to_config(conf_file, root_res);
+        let root_res = parse::parse(&parse_dir.unwrap());
+        util::write_to_config(&conf_file, root_res);
     } else {
         gen::generate(skip_validations, gen_dir.unwrap(), conf_file);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,11 +21,12 @@ fn main() {
     let conf_file = cli_values.conf_file.unwrap();
     let parse_opt = cli_values.parse;
     let parse_dir = cli_values.parse_dir;
+    let gen_dir = cli_values.gen_dir;
 
     if parse_opt {
         let root_res = parse::parse(parse_dir.unwrap());
         util::write_to_config(conf_file, root_res);
     } else {
-        gen::generate(skip_validations, conf_file);
+        gen::generate(skip_validations, gen_dir.unwrap(), conf_file);
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -38,13 +38,14 @@ fn parse_package(dir_path: &PathBuf) -> Package {
         let dir_entry = dir.unwrap();
         let dir_path = dir_entry.path();
         let file_name = dir_entry.file_name();
-        let file_name = file_name.to_str().unwrap();
+        let mut file_name = file_name.to_str().unwrap();
 
         let is_dir: bool = dir_entry.metadata().unwrap().is_dir();
 
         if is_dir == false {
 
             if file_name.ends_with(".py") && file_name != "__init__.py" {
+                file_name = file_name.split(".").collect::<Vec<_>>()[0];
                 pac_modules.push(parse_module(&dir_path, file_name));
             }
         } else {
@@ -118,8 +119,9 @@ pub fn parse(parse_dir: &str) -> Root {
 
         if is_dir == false {
             let file_name = dir_entry.file_name();
-            let file_name = file_name.to_str().unwrap();
+            let mut file_name = file_name.to_str().unwrap();
             if file_name.ends_with(".py") && file_name != "__init__.py" {
+                file_name = file_name.split(".").collect::<Vec<_>>()[0];
                 root_modules.push(parse_module(&dir_path, file_name));
             }
         } else {        

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -104,8 +104,8 @@ fn parse_module(dir_path: &PathBuf, file_name: &str) -> Module {
     module_res
 }
 
-pub fn parse(parse_dir: String) -> Root {
-    let root_name = parse_dir.clone();
+pub fn parse(parse_dir: &str) -> Root {
+    let root_name = parse_dir.clone().to_string();
     let dir_path = PathBuf::from(parse_dir);
     let dirs = fs::read_dir(dir_path).unwrap();
     let mut root_packages: Vec<Package> = Vec::new();

--- a/src/util.rs
+++ b/src/util.rs
@@ -62,7 +62,7 @@ pub fn write_to_config(conf_file: String, root: Root) {
 pub fn create_package(package_path: &Path) {
 	let init_file_path = INIT_FILE;
 
-	match fs::create_dir(package_path) {
+	match fs::create_dir_all(package_path) {
         Ok(_) => {},
         Err(e) => panic!("Failed to create package {}", e)
     };

--- a/src/util.rs
+++ b/src/util.rs
@@ -49,7 +49,7 @@ pub fn write_to_file(path: &Path, filename: &str, content: &str) {
 }
 
 /// Write the parsed content to a config file. (Toml/Yaml).
-pub fn write_to_config(conf_file: String, root: Root) {
+pub fn write_to_config(conf_file: &str, root: Root) {
     let mut file = fs::File::create(conf_file).unwrap();
     let config = Config {
         root: root

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,26 @@
+extern crate x_ray;
+
+
+use std::env;
+
+fn get_current_directory() -> String {
+    let cwd = env::current_dir().unwrap();
+    cwd.to_str().unwrap().to_string()
+}
+
+
+#[test]
+fn test_src_gen() {
+    let conf_file = "tests/test_gen.toml".to_string();
+    x_ray::gen(get_current_directory() + "/tests/test_py_gen", conf_file);
+}
+
+#[test]
+fn test_src_parse() {
+    let conf_file_gen = "tests/test_gen.toml".to_string();
+    x_ray::gen(get_current_directory() + "/tests/test_py_project", conf_file_gen);
+
+    let conf_file = "tests/test_parse.toml".to_string();
+    let parse_dir = "tests/test_py_project".to_string();
+    x_ray::parse(parse_dir, conf_file)
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,6 @@
 extern crate x_ray;
 
+mod util;
 
 use std::env;
 
@@ -8,19 +9,19 @@ fn get_current_directory() -> String {
     cwd.to_str().unwrap().to_string()
 }
 
-
 #[test]
-fn test_src_gen() {
-    let conf_file = "tests/test_gen.toml".to_string();
-    x_ray::gen(get_current_directory() + "/tests/test_py_gen", conf_file);
-}
-
-#[test]
-fn test_src_parse() {
+fn test_src_parse_gen() {
     let conf_file_gen = "tests/test_gen.toml".to_string();
+    let conf_file_parse = "tests/test_parse.toml".to_string();
+
+    // Test codegen.
+    let test_gen_toml_content = util::read_file(&conf_file_gen);
     x_ray::gen(get_current_directory() + "/tests/test_py_project", conf_file_gen);
 
-    let conf_file = "tests/test_parse.toml".to_string();
+    // Test parse.
     let parse_dir = "tests/test_py_project".to_string();
-    x_ray::parse(parse_dir, conf_file)
+    x_ray::parse(&parse_dir, &conf_file_parse);
+    let test_parse_toml_content = util::read_file(&conf_file_parse);
+
+    assert_eq!(test_gen_toml_content, test_parse_toml_content);
 }

--- a/tests/test_gen.toml
+++ b/tests/test_gen.toml
@@ -1,0 +1,37 @@
+[root]
+name = "root"
+
+[[root.packages]]
+name = "sample"
+
+[[root.packages.packages]]
+name = "nested_package"
+
+[[root.packages.modules]]
+name = "display"
+description = "This is the display module"
+
+[[root.packages.modules.classes]]
+name = "Animal"
+description = "This is the animal class"
+
+[[root.packages.modules.classes.methods]]
+name = "get_animal"
+description = "Get the animal instance of this object"
+
+[[root.packages.modules.functions]]
+name = "display"
+parameters = ["msg"]
+description = "this is the display function"
+
+[[root.packages]]
+name = "api"
+
+[[root.packages.modules]]
+name = "api"
+description = "This is the api module"
+
+[[root.packages.modules.functions]]
+name = "create_api"
+parameters = ["id", "new"]
+description = "This is the create api function"

--- a/tests/test_gen.toml
+++ b/tests/test_gen.toml
@@ -1,37 +1,43 @@
 [root]
-name = "root"
+modules = []
+name = "tests/test_py_project"
+
+[[root.packages]]
+name = "api"
+packages = []
+
+[[root.packages.modules]]
+classes = []
+description = "This is the api module"
+name = "api"
+
+[[root.packages.modules.functions]]
+description = "This is the create api function"
+name = "create_api"
+parameters = ["id", "new"]
 
 [[root.packages]]
 name = "sample"
 
-[[root.packages.packages]]
-name = "nested_package"
-
 [[root.packages.modules]]
-name = "display"
 description = "This is the display module"
+name = "display"
 
 [[root.packages.modules.classes]]
-name = "Animal"
 description = "This is the animal class"
+name = "Animal"
 
 [[root.packages.modules.classes.methods]]
-name = "get_animal"
 description = "Get the animal instance of this object"
+name = "get_animal"
+parameters = ["self"]
 
 [[root.packages.modules.functions]]
+description = "this is the display function"
 name = "display"
 parameters = ["msg"]
-description = "this is the display function"
 
-[[root.packages]]
-name = "api"
-
-[[root.packages.modules]]
-name = "api"
-description = "This is the api module"
-
-[[root.packages.modules.functions]]
-name = "create_api"
-parameters = ["id", "new"]
-description = "This is the create api function"
+[[root.packages.packages]]
+modules = []
+name = "nested_package"
+packages = []

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,0 +1,21 @@
+use std::fs::File;
+use std::io::prelude::*;
+
+pub fn read_file(filename: &str) -> String {
+    let file = File::open(filename);
+
+    let mut file_content = String::new();
+
+    let mut file = match file {
+        Ok(file) => file,
+        Err(error) => panic!("The following error occurred {:?}", error),
+    };
+
+    match file.read_to_string(&mut file_content) {
+        Ok(_) => {},
+        Err(error) => panic!("There was an error {:?} reading the file {}", error, filename),
+    }
+
+    // return the file content.
+    file_content
+}


### PR DESCRIPTION
use `create_dir_all` which recursively create a directory and all of its parent components if they are missing.

## Testing strategy

1. Generate python source code from `test_gen.toml`.
2. Parse the generated code (From above step) to generate `test_parse.toml`
3. `assert_eq!(test_gen_toml_content, test_parse_toml_content);`